### PR TITLE
Make installing dotfiles of symlink type useful

### DIFF
--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -15,7 +15,6 @@
             "request": "launch",
             "mode": "debug",
             "program": "${workspaceFolder}/cmd/dotf-tray"
-            //"args": ["--bla", "doesntexist", "--someboolean"]
         }
     ]
 }

--- a/pkg/cli/command.go
+++ b/pkg/cli/command.go
@@ -7,7 +7,7 @@ import (
 
 // Cli command specific flags
 const (
-	flagExternal string = "external"
+	FlagExternal string = "external"
 )
 
 // Command is the dotf type denoting a runnable and printable command

--- a/pkg/cli/install.go
+++ b/pkg/cli/install.go
@@ -72,7 +72,7 @@ func (c *installCommand) Run(args *parsing.CommandlineInput, conf *parsing.DotfC
 func (c *installCommand) externalInstall(file, externaldir string, conf *parsing.DotfConfiguration) error {
 	var dst string
 
-	_, err := terminalio.CopyDotfile(file, externaldir, conf.DotfilesDir, true)
+	_, err := terminalio.CopyExternalDotfile(file, externaldir, conf.DotfilesDir, true)
 	if err != nil {
 		switch e := err.(type) {
 		case *terminalio.ErrConfirmProceed:
@@ -81,7 +81,7 @@ func (c *installCommand) externalInstall(file, externaldir string, conf *parsing
 				logging.Info("Aborted by user")
 				return nil
 			}
-			dst, err = terminalio.CopyDotfile(file, externaldir, conf.DotfilesDir, false)
+			dst, err = terminalio.CopyExternalDotfile(file, externaldir, conf.DotfilesDir, false)
 			if err != nil {
 				return err
 			}

--- a/pkg/cli/install.go
+++ b/pkg/cli/install.go
@@ -2,7 +2,6 @@ package cli
 
 import (
 	"fmt"
-	"os"
 
 	"github.com/mortenskoett/dotf-go/pkg/logging"
 	"github.com/mortenskoett/dotf-go/pkg/parsing"
@@ -101,7 +100,7 @@ func (c *installCommand) internalInstall(file, userspacedir, dotfilesdir string)
 			logging.Warn(fmt.Sprintf("A file already exists in userspace: %s", logging.Color(e.Path, logging.Green)))
 			logging.Warn(fmt.Sprintf("It is required to backup and delete this file to install the dotfile."))
 
-			ok := ConfirmByUser("Do you want to continue?", os.Stdin)
+			ok := c.UserInteractor.ConfirmByUser("Do you want to continue?")
 			if ok {
 				return terminalio.InstallDotfile(file, userspacedir, dotfilesdir, ok) // Overwrite file
 			} else {

--- a/pkg/cli/install.go
+++ b/pkg/cli/install.go
@@ -37,7 +37,7 @@ func NewInstallCommand() *installCommand {
 		commandBase: &commandBase{
 			Name:     name,
 			Overview: "Install file/dir from dotfiles into userspace.",
-			Usage:    name + " <filepath> [--help]",
+			Usage:    name + " <filepath> [--<flags>] [--help]",
 			Args:     []arg{{Name: "file/dir", Description: "Path to file/dir inside dotfiles or path to file/dir in userspace."}},
 			Flags: []*parsing.Flag{
 				parsing.NewValueFlag(FlagExternal, "Install a dotfile from an external location.", "directory-path"),

--- a/pkg/cli/install_test.go
+++ b/pkg/cli/install_test.go
@@ -20,6 +20,69 @@ func (s mockInteractor) ConfirmByUser(question string) bool {
 	return cli.ConfirmByUser(question, &s.b)
 }
 
+func TestInstallExternalSymlink(t *testing.T) {
+	// Arrange
+	env := test.NewTestEnvironment()
+	defer env.Cleanup()
+
+	externalDotfilesDir := env.BackupDir // We use this as external dotfiles dir.
+	externalSharedFileToInstall := externalDotfilesDir.AddTempFile()
+	externalSymlinkToInstall := externalDotfilesDir.CreateTempSymlink(externalSharedFileToInstall.Path)
+
+	currentDotfilesDir := env.DotfilesDir
+	currentUserspaceDir := env.UserspaceDir
+
+	cliInput := &parsing.CommandlineInput{
+		CommandName:    "install",
+		PositionalArgs: []string{externalSymlinkToInstall.Path},
+		Flags: parsing.NewFlagHolder(map[string]string{
+			cli.FlagExternal: externalDotfilesDir.Path,
+		}),
+	}
+
+	dotfConf := &parsing.DotfConfiguration{
+		ConfigMetadata: &parsing.ConfigMetadata{},
+		UserspaceDir:   currentUserspaceDir.Path,
+		DotfilesDir:    currentDotfilesDir.Path,
+	}
+
+	// Use buffer instead of stdin
+	var stdin bytes.Buffer
+	stdin.Write([]byte("Y\n"))
+
+	// Act
+	cmd := cli.NewInstallCommand()
+	cmd.UserInteractor = mockInteractor{b: stdin} // Insert buffer
+	err := cmd.Run(cliInput, dotfConf)
+	if err != nil {
+		t.Errorf("%+v", err)
+	}
+
+	// Asserts
+
+	// assert copied over config exists in dotfiles dir
+	expectedDotfilesFile := filepath.Join(currentDotfilesDir.Path, externalSymlinkToInstall.Name)
+	if exists, _ := terminalio.CheckIfFileExists(expectedDotfilesFile); !exists {
+		t.Errorf("A new config pointed to from userspace should now exists now on in dotfiles on path: %v, opt error: %+v", expectedDotfilesFile, err)
+	}
+
+	// check if new file in dotfiles is in fact symlink
+	if ok, err := terminalio.IsFileSymlink(expectedDotfilesFile); !ok || err != nil {
+		t.Errorf("File in dotfiles dir should be a symlink pointing to the actual file (probably in shared). This is not a symlink: %s: %v", expectedDotfilesFile, err)
+	}
+
+	// assert symlink exists in userspace
+	expectedUserspacePath := filepath.Join(currentUserspaceDir.Path, externalSymlinkToInstall.Name)
+	if exists, err := terminalio.CheckIfFileExists(expectedUserspacePath); !exists {
+		t.Errorf("A symlink pointing from userspace to dotfiles should exists now on path: %v, opt error: %+v", expectedUserspacePath, err)
+	}
+
+	// check if new file in userspace is in fact symlink
+	if ok, err := terminalio.IsFileSymlink(expectedUserspacePath); !ok || err != nil {
+		t.Errorf("File in userspace dir should be a symlink. This is not a symlink: %s: %v", expectedUserspacePath, err)
+	}
+}
+
 func TestInstallExternalFile(t *testing.T) {
 	// Arrange
 	env := test.NewTestEnvironment()

--- a/pkg/cli/install_test.go
+++ b/pkg/cli/install_test.go
@@ -1,0 +1,79 @@
+package cli_test
+
+import (
+	"bytes"
+	"path/filepath"
+	"testing"
+
+	"github.com/mortenskoett/dotf-go/pkg/cli"
+	"github.com/mortenskoett/dotf-go/pkg/parsing"
+	"github.com/mortenskoett/dotf-go/pkg/terminalio"
+	"github.com/mortenskoett/dotf-go/pkg/test"
+)
+
+// For tests.
+type mockInteractor struct {
+	b bytes.Buffer
+}
+
+func (s mockInteractor) ConfirmByUser(question string) bool {
+	return cli.ConfirmByUser(question, &s.b)
+}
+
+func TestInstallExternalFile(t *testing.T) {
+	// Arrange
+	env := test.NewTestEnvironment()
+	defer env.Cleanup()
+
+	externalDotfilesDir := env.BackupDir // We use this as external dotfiles dir.
+	externalFileToInstall := externalDotfilesDir.AddTempFile()
+
+	currentDotfilesDir := env.DotfilesDir
+	currentUserspaceDir := env.UserspaceDir
+
+	cliInput := &parsing.CommandlineInput{
+		CommandName:    "install",
+		PositionalArgs: []string{externalFileToInstall.Path},
+		Flags: parsing.NewFlagHolder(map[string]string{
+			cli.FlagExternal: externalDotfilesDir.Path,
+		}),
+	}
+
+	dotfConf := &parsing.DotfConfiguration{
+		ConfigMetadata: &parsing.ConfigMetadata{},
+		UserspaceDir:   currentUserspaceDir.Path,
+		DotfilesDir:    currentDotfilesDir.Path,
+	}
+
+	// Use buffer instead of stdin
+	var stdin bytes.Buffer
+	stdin.Write([]byte("Y\n"))
+
+	// Act
+	cmd := cli.NewInstallCommand()
+	cmd.UserInteractor = mockInteractor{b: stdin} // Insert buffer
+	err := cmd.Run(cliInput, dotfConf)
+	if err != nil {
+		t.Errorf("%+v", err)
+	}
+
+	// Asserts
+
+	// assert copied over config exists in dotfiles dir
+	expectedDotfilesFile := filepath.Join(currentDotfilesDir.Path, externalFileToInstall.Name)
+	if exists, _ := terminalio.CheckIfFileExists(expectedDotfilesFile); !exists {
+		t.Errorf("A new config pointed to from userspace should now exists now on in dotfiles on path: %v, opt error: %+v", expectedDotfilesFile, err)
+	}
+
+	// assert symlink exists in userspace
+	expectedUserspacePath := filepath.Join(currentUserspaceDir.Path, externalFileToInstall.Name)
+	if exists, err := terminalio.CheckIfFileExists(expectedUserspacePath); !exists {
+		t.Errorf("A symlink pointing from userspace to dotfiles should exists now on path: %v, opt error: %+v", expectedUserspacePath, err)
+	}
+
+	// check if new file in userspace is in fact symlink
+	if ok, err := terminalio.IsFileSymlink(expectedUserspacePath); !ok || err != nil {
+		t.Errorf("File in userspace dir should be a symlink at %s: %v", expectedUserspacePath, err)
+	}
+
+}

--- a/pkg/cli/migrate.go
+++ b/pkg/cli/migrate.go
@@ -9,6 +9,7 @@ import (
 // Implements Command interface
 type migrateCommand struct {
 	*commandBase
+	UserInteractor UserInteractor
 }
 
 func NewMigrateCommand() *migrateCommand {
@@ -28,7 +29,7 @@ func NewMigrateCommand() *migrateCommand {
 	new location directory.`
 
 	return &migrateCommand{
-		&commandBase{
+		commandBase: &commandBase{
 			Name:     name,
 			Overview: "Migrate userspace symlinks on changed dotfiles location.",
 			Usage:    name + " <dotfiles-dir> <userspace-dir> [--help]",
@@ -39,11 +40,12 @@ func NewMigrateCommand() *migrateCommand {
 			Flags:       []*parsing.Flag{},
 			Description: desc,
 		},
+		UserInteractor: StdInUserInteractor{},
 	}
 }
 
 func (c *migrateCommand) Run(args *parsing.CommandlineInput, conf *parsing.DotfConfiguration) error {
-	ok := confirmByUser("This operation can be desctructive. Do you want to continue?")
+	ok := c.UserInteractor.ConfirmByUser("This operation can be desctructive. Do you want to continue?")
 	if !ok {
 		logging.Warn("Aborted by user")
 		return nil
@@ -60,4 +62,3 @@ func (c *migrateCommand) Run(args *parsing.CommandlineInput, conf *parsing.DotfC
 	logging.Ok("\nAll symlinks have been updated successfully.")
 	return nil
 }
-

--- a/pkg/cli/print.go
+++ b/pkg/cli/print.go
@@ -91,27 +91,29 @@ func generateUsage(c CommandPrintable) string {
 	// TODO: Fix duplicated code for printing of args and flags below.
 
 	// Print arguments.
-	sb.WriteString("\n\nArguments:\n")
-	tabbuf := &bytes.Buffer{}
-	w := new(tabwriter.Writer)
-	w.Init(tabbuf, 0, 8, 8, ' ', 0)
+	if len(c.getArgs()) > 0 {
+		sb.WriteString("\n\nArguments:\n")
+		tabbuf := &bytes.Buffer{}
+		w := new(tabwriter.Writer)
+		w.Init(tabbuf, 0, 8, 8, ' ', 0)
 
-	for _, arg := range c.getArgs() {
-		buf := &bytes.Buffer{}
-		buf.WriteString("<")
-		buf.WriteString(arg.Name)
-		buf.WriteString(">")
-		str := fmt.Sprintf("\t%s\t%s", buf, arg.Description)
-		fmt.Fprintln(w, str)
+		for _, arg := range c.getArgs() {
+			buf := &bytes.Buffer{}
+			buf.WriteString("<")
+			buf.WriteString(arg.Name)
+			buf.WriteString(">")
+			str := fmt.Sprintf("\t%s\t%s", buf, arg.Description)
+			fmt.Fprintln(w, str)
+		}
+		w.Flush()
+		sb.WriteString(tabbuf.String())
 	}
-	w.Flush()
-	sb.WriteString(tabbuf.String())
 
 	// Print flags.
 	if len(c.getFlags()) > 0 {
 		sb.WriteString("\nFlags:\n")
-		tabbuf = &bytes.Buffer{}
-		w = new(tabwriter.Writer)
+		tabbuf := &bytes.Buffer{}
+		w := new(tabwriter.Writer)
 		w.Init(tabbuf, 0, 8, 8, ' ', 0)
 
 		for _, flag := range c.getFlags() {

--- a/pkg/cli/print.go
+++ b/pkg/cli/print.go
@@ -4,6 +4,7 @@ import (
 	"bufio"
 	"bytes"
 	"fmt"
+	"io"
 	"os"
 	"strings"
 	"text/tabwriter"
@@ -109,9 +110,22 @@ func generateUsage(c CommandPrintable) string {
 	return sb.String()
 }
 
-// Displays a yes/no prompt to the user and returns the boolean value of the answer
-func confirmByUser(question string) bool {
-	reader := bufio.NewReader(os.Stdin)
+type UserInteractor interface {
+	ConfirmByUser(question string) bool
+}
+
+type StdInUserInteractor struct {
+}
+
+// Implements UserInteractor.
+func (s StdInUserInteractor) ConfirmByUser(question string) bool {
+	return ConfirmByUser(question, os.Stdin)
+}
+
+// Displays a yes/no prompt to the user and returns the boolean value of the answer. Stdin is
+// parameterized to make the function testable.
+func ConfirmByUser(question string, stdin io.Reader) bool {
+	reader := bufio.NewReader(stdin)
 
 	for {
 		logging.Warn(question)

--- a/pkg/cli/print.go
+++ b/pkg/cli/print.go
@@ -88,9 +88,10 @@ func generateUsage(c CommandPrintable) string {
 	sb.WriteString("\n\nUsage:\n\t")
 	sb.WriteString(c.getUsage())
 
-	sb.WriteString("\n\nArguments:\n")
+	// TODO: Fix duplicated code for printing of args and flags below.
 
 	// Print arguments.
+	sb.WriteString("\n\nArguments:\n")
 	tabbuf := &bytes.Buffer{}
 	w := new(tabwriter.Writer)
 	w.Init(tabbuf, 0, 8, 8, ' ', 0)
@@ -103,9 +104,27 @@ func generateUsage(c CommandPrintable) string {
 		str := fmt.Sprintf("\t%s\t%s", buf, arg.Description)
 		fmt.Fprintln(w, str)
 	}
-
 	w.Flush()
 	sb.WriteString(tabbuf.String())
+
+	// Print flags.
+	if len(c.getFlags()) > 0 {
+		sb.WriteString("\nFlags:\n")
+		tabbuf = &bytes.Buffer{}
+		w = new(tabwriter.Writer)
+		w.Init(tabbuf, 0, 8, 8, ' ', 0)
+
+		for _, flag := range c.getFlags() {
+			buf := &bytes.Buffer{}
+			buf.WriteString("<")
+			buf.WriteString(flag.Name)
+			buf.WriteString(">")
+			str := fmt.Sprintf("\t%s\t%s", buf, flag.Description)
+			fmt.Fprintln(w, str)
+		}
+		w.Flush()
+		sb.WriteString(tabbuf.String())
+	}
 
 	return sb.String()
 }

--- a/pkg/cli/print_test.go
+++ b/pkg/cli/print_test.go
@@ -1,0 +1,41 @@
+package cli_test
+
+import (
+	"bytes"
+	"testing"
+
+	"github.com/mortenskoett/dotf-go/pkg/cli"
+)
+
+func TestConfirmByUserYesReturnsTrue(t *testing.T) {
+	testcases := []struct {
+		input          string
+		expectedResult bool
+	}{
+		{
+			input:          "Y",
+			expectedResult: true,
+		},
+		{
+			input:          "yes",
+			expectedResult: true,
+		},
+		{
+			input:          "n",
+			expectedResult: false,
+		},
+		{
+			input:          "no",
+			expectedResult: false,
+		},
+	}
+
+	for _, tc := range testcases {
+		var stdin bytes.Buffer
+		stdin.Write([]byte(tc.input + "\n"))
+		actualResult := cli.ConfirmByUser("Some great question?", &stdin)
+		if tc.expectedResult != actualResult {
+			t.Errorf("Handling of user input was not as expected: got: %+v, want %+v. Info: %+v", actualResult, tc.expectedResult, tc)
+		}
+	}
+}

--- a/pkg/cli/setup.go
+++ b/pkg/cli/setup.go
@@ -10,6 +10,7 @@ import (
 
 type setupCommand struct {
 	*commandBase
+	UserInteractor UserInteractor
 }
 
 func NewSetupCommand() *setupCommand {
@@ -32,6 +33,7 @@ func NewSetupCommand() *setupCommand {
 			Flags:       flags,
 			Description: description,
 		},
+		UserInteractor: StdInUserInteractor{},
 	}
 }
 
@@ -51,7 +53,7 @@ func (c *setupCommand) Run(args *parsing.CommandlineInput, _ *parsing.DotfConfig
 		case *terminalio.ErrAbortOnOverwrite:
 			logging.Warn(fmt.Sprintf("A config file already exists: %s", logging.Color(e.Path, logging.Green)))
 			logging.Warn(logging.Color("Current configuration will be OVERWRITTEN if you say so", logging.Red))
-			ok := confirmByUser("Do you want to continue?")
+			ok := c.UserInteractor.ConfirmByUser("Do you want to continue?")
 			if ok {
 				if err := terminalio.WriteFile(config.Filepath, bs, ok); err != nil {
 					return err

--- a/pkg/terminalio/file.go
+++ b/pkg/terminalio/file.go
@@ -15,7 +15,7 @@ import (
 
 // Contains info about a files whereabouts in relation to dotfiles dir and userspace.
 type fileLocationInfo struct {
-	insideDotfiles bool   // Whether the org filepath was to a file inside dotfiles
+	insideDotfiles bool   // Whether the filepath was to a file inside dotfiles
 	fileOrgPath    string // Absolute path of given file
 	userspaceFile  string // Absolute path to file in userspace
 	dotfilesFile   string // Absolute path to file in dotfiles

--- a/pkg/terminalio/file.go
+++ b/pkg/terminalio/file.go
@@ -28,11 +28,24 @@ func GetAndValidateAbsolutePath(path string) (string, error) {
 	if err != nil {
 		return "", err
 	}
-	if exists, _ := checkIfFileExists(path); !exists {
+	if exists, _ := CheckIfFileExists(path); !exists {
 		return "", &ErrFileNotFound{path}
 	}
 
 	return path, nil
+}
+
+// Checks if file exists by trying to open it. The given path should be absolute or relative to
+// dotf executable. An error is returned if the file does not exist.
+func CheckIfFileExists(absPath string) (bool, error) {
+	_, err := os.Open(absPath)
+	if err != nil {
+		if errors.Is(err, os.ErrNotExist) {
+			return false, nil
+		}
+		return false, err
+	}
+	return true, nil
 }
 
 // Finds common prefix of two already split strings. E.g. '/a/b/c' and '/a/b/c/d' gives 'a/b/c'.
@@ -177,7 +190,7 @@ func writeFile(fpath string, contents []byte) error {
 		return err
 	}
 
-	if exists, _ := checkIfFileExists(absPath); !exists {
+	if exists, _ := CheckIfFileExists(absPath); !exists {
 		return &ErrFileNotFound{absPath}
 	}
 	return nil
@@ -383,19 +396,6 @@ func expandTilde(path string) string {
 		return filepath.Join(dirname, path[2:])
 	}
 	return path
-}
-
-// Checks if file exists by trying to open it. The given path should be absolute or relative to
-// dotf executable. An error is returned if the file does not exist.
-func checkIfFileExists(absPath string) (bool, error) {
-	_, err := os.Open(absPath)
-	if err != nil {
-		if errors.Is(err, os.ErrNotExist) {
-			return false, nil
-		}
-		return false, err
-	}
-	return true, nil
 }
 
 func isDirectory(src string) (bool, error) {

--- a/pkg/terminalio/file_test.go
+++ b/pkg/terminalio/file_test.go
@@ -354,7 +354,7 @@ func Test_checkIfFileExists_determines_files_exist(t *testing.T) {
 
 	file := env.UserspaceDir.AddTempFile()
 
-	if exists, _ := checkIfFileExists(file.Path); !exists {
+	if exists, _ := CheckIfFileExists(file.Path); !exists {
 		test.Fail(exists, "Should not fail as file exists.", t)
 	}
 }
@@ -365,7 +365,7 @@ func Test_checkIfFileExists_determines_dirs_exist(t *testing.T) {
 
 	dir := env.UserspaceDir.AddTempDir("mytestdir")
 
-	if exists, _ := checkIfFileExists(dir.Path); !exists {
+	if exists, _ := CheckIfFileExists(dir.Path); !exists {
 		test.Fail(exists, "Should not fail as file exists.", t)
 	}
 }
@@ -407,17 +407,17 @@ func Test_copyDir_copies_recursively_files_folders(t *testing.T) {
 	}
 
 	// Dst folder and content should exist
-	if exists, _ := checkIfFileExists(res); !exists {
+	if exists, _ := CheckIfFileExists(res); !exists {
 		test.Fail(res, "File does not exist", t)
 	}
-	if exists, _ := checkIfFileExists(dstInsideFile); !exists {
+	if exists, _ := CheckIfFileExists(dstInsideFile); !exists {
 		test.Fail(dstInsideFile, "File does not exist", t)
 	}
-	if exists, _ := checkIfFileExists(dstHereFile); !exists {
+	if exists, _ := CheckIfFileExists(dstHereFile); !exists {
 		test.Fail(dstHereFile, "File does not exist", t)
 	}
 	// Src folder should NOT have been deleted
-	if exists, _ := checkIfFileExists(src.Path); !exists {
+	if exists, _ := CheckIfFileExists(src.Path); !exists {
 		test.Fail(src.Path, "Dir should still exist", t)
 	}
 }
@@ -429,7 +429,7 @@ func Test_deleteDirectory_deletes_existing_directory(t *testing.T) {
 	d := env.UserspaceDir.AddTempDir("dirtodelete").Path
 
 	// check if dir exists
-	if exists, _ := checkIfFileExists(d); !exists {
+	if exists, _ := CheckIfFileExists(d); !exists {
 		test.Fail(exists, "dir should exist", t)
 	}
 
@@ -449,7 +449,7 @@ func Test_deleteDirectory_deletes_existing_directory(t *testing.T) {
 	}
 
 	// check if deleted properly
-	if exists, _ := checkIfFileExists(d); exists {
+	if exists, _ := CheckIfFileExists(d); exists {
 		test.Fail(exists, "dir should NOT exist now", t)
 	}
 }
@@ -460,7 +460,7 @@ func Test_deleteFile_deletes_existing_file(t *testing.T) {
 
 	f := env.UserspaceDir.AddTempFile().Path
 
-	if exists, _ := checkIfFileExists(f); !exists {
+	if exists, _ := CheckIfFileExists(f); !exists {
 		test.Fail(exists, "file should exist", t)
 	}
 
@@ -469,7 +469,7 @@ func Test_deleteFile_deletes_existing_file(t *testing.T) {
 		test.Fail(err, "shouldnt fail", t)
 	}
 
-	if exists, _ := checkIfFileExists(f); exists {
+	if exists, _ := CheckIfFileExists(f); exists {
 		test.Fail(exists, "file should NOT exist now", t)
 	}
 }

--- a/pkg/terminalio/ops.go
+++ b/pkg/terminalio/ops.go
@@ -27,7 +27,7 @@ func AddDotfile(userspaceFile, userspaceHomedir, dotfilesDir string) error {
 	}
 
 	// Assert a file is not already in dotfiles dir at location
-	exists, err := checkIfFileExists(absNewDotFile)
+	exists, err := CheckIfFileExists(absNewDotFile)
 	if err != nil {
 		return err
 	}
@@ -92,7 +92,7 @@ func CopyDotfile(fpath, fromdir, todir string, confirm bool) (string, error) {
 	}
 
 	// Assert a file is not already in dotfiles dir at location
-	exists, err := checkIfFileExists(absNewDotfile)
+	exists, err := CheckIfFileExists(absNewDotfile)
 	if err != nil {
 		return "", err
 	}
@@ -112,7 +112,7 @@ func CopyDotfile(fpath, fromdir, todir string, confirm bool) (string, error) {
 
 // Writes a file to disk
 func WriteFile(fpath string, contents []byte, overwrite bool) error {
-	exists, err := checkIfFileExists(fpath)
+	exists, err := CheckIfFileExists(fpath)
 	if err != nil {
 		return err
 	}
@@ -151,7 +151,7 @@ func InstallDotfile(file, userspaceDir, dotfilesDir string, overwrite bool) erro
 	}
 
 	// Check whether dotfile exists
-	exists, err := checkIfFileExists(info.dotfilesFile)
+	exists, err := CheckIfFileExists(info.dotfilesFile)
 	if err != nil {
 		return err
 	}
@@ -160,7 +160,7 @@ func InstallDotfile(file, userspaceDir, dotfilesDir string, overwrite bool) erro
 	}
 
 	// Check whtether userspace file already exists
-	exists, err = checkIfFileExists(info.userspaceFile)
+	exists, err = CheckIfFileExists(info.userspaceFile)
 	if err != nil {
 		return err
 	}
@@ -200,7 +200,7 @@ func RevertDotfile(file, userspaceDir, dotfilesDir string) error {
 	usersymlink := info.userspaceFile
 
 	// Check whtether file and symlink exists
-	ok, err := checkIfFileExists(dotfile)
+	ok, err := CheckIfFileExists(dotfile)
 	if err != nil {
 		return err
 	}
@@ -208,7 +208,7 @@ func RevertDotfile(file, userspaceDir, dotfilesDir string) error {
 		return &ErrFileNotFound{dotfile}
 	}
 
-	ok, err = isFileSymlink(usersymlink)
+	ok, err = IsFileSymlink(usersymlink)
 	if err != nil {
 		return err
 	}

--- a/pkg/terminalio/ops_test.go
+++ b/pkg/terminalio/ops_test.go
@@ -316,7 +316,7 @@ func Test_CopyDotfile_successfully_copies_file_into_dotfiles(t *testing.T) {
 	userspaceFile := dir.AddTempFile()
 
 	// Function under test
-	dst, err := CopyDotfile(userspaceFile.Path, userspacedir.Path, dfilesdir.Path, false)
+	dst, err := CopyExternalDotfile(userspaceFile.Path, userspacedir.Path, dfilesdir.Path, false)
 	if err != nil {
 		test.Fail(err, "No error should have happened", t)
 	}

--- a/pkg/terminalio/ops_test.go
+++ b/pkg/terminalio/ops_test.go
@@ -65,7 +65,7 @@ func Test_InstallDotfile_creates_existing_symlink_in_userspace_with_overwrite(t 
 	defer fdst.Close()
 
 	// Assert file is indeed created
-	exists, err := checkIfFileExists(uspaceSymlinkPath)
+	exists, err := CheckIfFileExists(uspaceSymlinkPath)
 	if err != nil {
 		test.FailHard(err, "No error should have happened", t)
 	}
@@ -79,7 +79,7 @@ func Test_InstallDotfile_creates_existing_symlink_in_userspace_with_overwrite(t 
 	}
 
 	// Assert symlink exists in uspace
-	ok, err := isFileSymlink(uspaceSymlinkPath)
+	ok, err := IsFileSymlink(uspaceSymlinkPath)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -114,7 +114,7 @@ func Test_InstallDotfile_creates_existing_symlink_in_userspace_no_overwrite(t *t
 	}
 
 	// Assert symlink exists in uspace
-	ok, err := isFileSymlink(uspaceSymlinkPath)
+	ok, err := IsFileSymlink(uspaceSymlinkPath)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -139,7 +139,7 @@ func Test_InstallDotfile_creates_not_existing_symlink_in_userspace_no_overwrite(
 	}
 
 	// Assert symlink exists in uspace
-	ok, err := isFileSymlink(uspaceSymlinkPath)
+	ok, err := IsFileSymlink(uspaceSymlinkPath)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -164,7 +164,7 @@ func Test_RevertDotfile_deletes_symlink_and_moves_file_back_userspace(t *testing
 	}
 
 	// Assert symlink exists
-	ok, err := isFileSymlink(uspaceSymlinkPath)
+	ok, err := IsFileSymlink(uspaceSymlinkPath)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -179,7 +179,7 @@ func Test_RevertDotfile_deletes_symlink_and_moves_file_back_userspace(t *testing
 	}
 
 	// Assert symlink has become a file and NOT still symlink
-	ok, err = isFileSymlink(uspaceSymlinkPath)
+	ok, err = IsFileSymlink(uspaceSymlinkPath)
 	if err != nil {
 		test.FailHard(err, "No error should have happened", t)
 	}
@@ -188,7 +188,7 @@ func Test_RevertDotfile_deletes_symlink_and_moves_file_back_userspace(t *testing
 	}
 
 	// Assert file is not there anymore
-	exists, err := checkIfFileExists(dsomefile.Path)
+	exists, err := CheckIfFileExists(dsomefile.Path)
 	if err != nil {
 		test.FailHard(err, "No error should have happened", t)
 	}
@@ -213,7 +213,7 @@ func Test_RevertDotfile_deletes_symlink_and_moves_file_back_dotfiles(t *testing.
 	}
 
 	// Assert symlink exists
-	ok, err := isFileSymlink(uspaceSymlinkPath)
+	ok, err := IsFileSymlink(uspaceSymlinkPath)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -228,7 +228,7 @@ func Test_RevertDotfile_deletes_symlink_and_moves_file_back_dotfiles(t *testing.
 	}
 
 	// Assert symlink has become a file and NOT still symlink
-	ok, err = isFileSymlink(uspaceSymlinkPath)
+	ok, err = IsFileSymlink(uspaceSymlinkPath)
 	if err != nil {
 		test.FailHard(err, "No error should have happened", t)
 	}
@@ -237,7 +237,7 @@ func Test_RevertDotfile_deletes_symlink_and_moves_file_back_dotfiles(t *testing.
 	}
 
 	// Assert file is not there anymore
-	exists, err := checkIfFileExists(dsomefile.Path)
+	exists, err := CheckIfFileExists(dsomefile.Path)
 	if err != nil {
 		test.FailHard(err, "No error should have happened", t)
 	}
@@ -281,24 +281,24 @@ func Test_AddFileToDotfiles_successfully_copies_file_creates_symlink(t *testing.
 	expectedBackupFile := filepath.Join("/tmp/dotf-go/backups", userspaceFile.Path)
 
 	// check if new file in dotfiles exist
-	if exists, _ := checkIfFileExists(expectedDotfilesFile); !exists {
+	if exists, _ := CheckIfFileExists(expectedDotfilesFile); !exists {
 		test.Fail(exists, fmt.Sprintf("File in dotfiles dir should exist at %s", expectedDotfilesFile), t)
 	}
 
 	// check if new file at userspace location exists
-	if exists, err := checkIfFileExists(userspaceFile.Path); !exists {
+	if exists, err := CheckIfFileExists(userspaceFile.Path); !exists {
 		test.Fail(exists, fmt.Sprintf(
 			"File in userspace dir should still exist at %s: %v", userspaceFile.Path, err), t)
 	}
 
 	// check if new file at userspace location is symlink
-	if ok, _ := isFileSymlink(userspaceFile.Path); !ok {
+	if ok, _ := IsFileSymlink(userspaceFile.Path); !ok {
 		test.Fail(ok, fmt.Sprintf(
 			"File in userspace dir should be a symlink at %s: %v", userspaceFile.Path, err), t)
 	}
 
 	// check if backup exists
-	if exists, err := checkIfFileExists(expectedBackupFile); !exists {
+	if exists, err := CheckIfFileExists(expectedBackupFile); !exists {
 		test.Fail(exists, fmt.Sprintf(
 			"File from userspace should be backed up to %s: %v", expectedBackupFile, err), t)
 	}
@@ -325,7 +325,7 @@ func Test_CopyDotfile_successfully_copies_file_into_dotfiles(t *testing.T) {
 	expectedBackupFile := filepath.Join("/tmp/dotf-go/backups", userspaceFile.Path)
 
 	// check if new file in dotfiles exist
-	if exists, _ := checkIfFileExists(expectedDotfilesFile); !exists {
+	if exists, _ := CheckIfFileExists(expectedDotfilesFile); !exists {
 		test.Fail(exists, fmt.Sprintf("File in dotfiles dir should exist at %s", expectedDotfilesFile), t)
 	}
 
@@ -335,13 +335,13 @@ func Test_CopyDotfile_successfully_copies_file_into_dotfiles(t *testing.T) {
 	}
 
 	// check if new file at userspace location exists
-	if exists, err := checkIfFileExists(userspaceFile.Path); !exists {
+	if exists, err := CheckIfFileExists(userspaceFile.Path); !exists {
 		test.Fail(exists, fmt.Sprintf(
 			"File in userspace dir should still exist at %s: %v", userspaceFile.Path, err), t)
 	}
 
 	// check if backup exists
-	if exists, err := checkIfFileExists(expectedBackupFile); !exists {
+	if exists, err := CheckIfFileExists(expectedBackupFile); !exists {
 		test.Fail(exists, fmt.Sprintf(
 			"File from userspace should be backed up to %s: %v", expectedBackupFile, err), t)
 	}

--- a/pkg/terminalio/symlink.go
+++ b/pkg/terminalio/symlink.go
@@ -67,7 +67,7 @@ func UpdateSymlinks(userSpaceDir, dotfilesDir string) error {
 	})
 }
 
-// IsFileSymlink returns true if the given path is an existsing symlink.
+// IsFileSymlink returns true if the given path is an existing symlink.
 func IsFileSymlink(file string) (bool, error) {
 	fileInfo, err := os.Lstat(file)
 	if err != nil {
@@ -94,12 +94,12 @@ func updateSymlink(fromDest, toFile string) error {
 }
 
 // Create a symlink at location 'symlinkDest' pointing to an actual file that should exist at
-// 'fileDest'.
-func createSymlink(symlinkDest, fileDest string) error {
-	err := os.Symlink(fileDest, symlinkDest)
+// 'fileSrc'.
+func createSymlink(symlinkDest, fileSrc string) error {
+	err := os.Symlink(fileSrc, symlinkDest)
 	if err != nil {
-		return fmt.Errorf("failed to create symlink from %s -> %s: %w", symlinkDest, fileDest, err)
+		return fmt.Errorf("failed to create symlink from %s -> %s: %w", symlinkDest, fileSrc, err)
 	}
-	logging.Ok("Symlink successfully created from", symlinkDest, "->", fileDest) // from symlink -> file
+	logging.Ok("Symlink successfully created from", symlinkDest, "->", fileSrc) // from symlink -> file
 	return nil
 }

--- a/pkg/terminalio/symlink.go
+++ b/pkg/terminalio/symlink.go
@@ -42,7 +42,7 @@ func UpdateSymlinks(userSpaceDir, dotfilesDir string) error {
 			return err
 		}
 
-		exists, err := checkIfFileExists(fileInUserspace)
+		exists, err := CheckIfFileExists(fileInUserspace)
 		if err != nil {
 			return err
 		}
@@ -51,7 +51,7 @@ func UpdateSymlinks(userSpaceDir, dotfilesDir string) error {
 			return nil
 		}
 
-		ok, err := isFileSymlink(fileInUserspace)
+		ok, err := IsFileSymlink(fileInUserspace)
 		if err != nil {
 			return err
 		}
@@ -65,6 +65,15 @@ func UpdateSymlinks(userSpaceDir, dotfilesDir string) error {
 
 		return nil
 	})
+}
+
+// IsFileSymlink returns true if the given path is an existsing symlink.
+func IsFileSymlink(file string) (bool, error) {
+	fileInfo, err := os.Lstat(file)
+	if err != nil {
+		return false, fmt.Errorf("failed to determine file is a symlink: %w", err)
+	}
+	return fileInfo.Mode()&os.ModeSymlink == os.ModeSymlink, nil
 }
 
 // updateSymlink updates an existing symlink found at location 'fromDest' to point to an existing
@@ -93,13 +102,4 @@ func createSymlink(symlinkDest, fileDest string) error {
 	}
 	logging.Ok("Symlink successfully created from", symlinkDest, "->", fileDest) // from symlink -> file
 	return nil
-}
-
-// isFileSymlink returns true if the given path is an existsing symlink.
-func isFileSymlink(file string) (bool, error) {
-	fileInfo, err := os.Lstat(file)
-	if err != nil {
-		return false, fmt.Errorf("failed to determine file is a symlink: %w", err)
-	}
-	return fileInfo.Mode()&os.ModeSymlink == os.ModeSymlink, nil
 }

--- a/pkg/terminalio/symlink_test.go
+++ b/pkg/terminalio/symlink_test.go
@@ -30,7 +30,7 @@ func Test_UpdateSymlinks_recursively_changes_symlinks_in_userspace(t *testing.T)
 	}
 
 	// Assert symlink exists
-	ok, err := isFileSymlink(somesymlinkpath)
+	ok, err := IsFileSymlink(somesymlinkpath)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -171,7 +171,7 @@ func Test_createSymlink_creates_dir_file_symlink(t *testing.T) {
 			test.FailHard(err, "shouldn't fail here", t)
 		}
 
-		ok, err := isFileSymlink(in.symlink)
+		ok, err := IsFileSymlink(in.symlink)
 		if err != nil {
 			test.FailHard(err, "Not expected to fail", t)
 		}
@@ -217,7 +217,7 @@ func Test_isFileSymlink_determines_correctly_a_symlink(t *testing.T) {
 	}
 
 	for _, tc := range tests {
-		ok, err := isFileSymlink(tc.symlink)
+		ok, err := IsFileSymlink(tc.symlink)
 		if err != nil {
 			if !tc.shoulderr {
 				test.Fail(err, "shouldn't fail here", t)


### PR DESCRIPTION
When using the install command. If a symlink is detected that will now be copied to current dotfiles dir first, and then a symlink to that symlink is then created in userspace.