### PR TITLE
Extend install command to source shared configs

### DIFF
--- a/.vimspector.json
+++ b/.vimspector.json
@@ -7,7 +7,11 @@
         "request": "launch",
         "program": "${fileDirname}",
         "mode": "debug",
-        "dlvToolPath": "/usr/bin/dlv"
+        "dlvToolPath": "/usr/bin/dlv",
+        "args": [
+          "install",
+          "jabba/yeah/mofo"
+        ]
       }
     },
     "Run smart": {

--- a/Makefile
+++ b/Makefile
@@ -29,6 +29,10 @@ install: build install-cli install-tray ## Install all applications.
 test: ## Run tests.
 	go test ./pkg/...
 
+.PHONY: install-arch-deps
+install-arch-deps: ## Installs tray app deps for arch
+	sudo pacman -S libayatana-appindicator
+
 .PHONY: install-ubuntu-deps
 install-ubuntu-deps: ## Installs tray app deps for ubuntu
 	sudo apt-get install gcc libgtk-3-dev libayatana-appindicator3-dev

--- a/pkg/parsing/config.go
+++ b/pkg/parsing/config.go
@@ -28,31 +28,34 @@ var (
 
 // Defaults
 var (
-	defaultConfigDir   = configdir + "/dotf/config"
-	defaultSyncDir     = homedir + "/dotfiles"
-	defaultDistrosDir  = defaultSyncDir + "/distros"
-	defaultDotfilesDir = defaultSyncDir + "/" + hostname
+	defaultConfigDir         = configdir + "/dotf/config"
+	defaultSyncDir           = homedir + "/dotfiles"
+	defaultDistrosDir        = defaultSyncDir + "/distros"
+	defaultDotfilesDir       = defaultDistrosDir + "/" + hostname
+	defaultSharedDotfilesDir = defaultSyncDir + "/shared/dotfiles"
 )
 
-// Configurations that will be parsed from the config file
+// Configurations mapping strings that will be parsed from the config file.
 const (
-	userspacedir     = "userspacedir"
-	distrosdir       = "distrosdir"
-	dotfilesdir      = "dotfilesdir"
-	syncdir          = "syncdir"
-	autosync         = "autosync"
-	syncintervalsecs = "syncintervalsecs"
+	userspace_dir       = "userspace_dir"
+	dotfiles_dir        = "dotfiles_dir"
+	dotfiles_shared_dir = "dotfiles_shared_dir"
+	sync_dir            = "sync_dir"
+	sync_interval_secs  = "sync_interval_secs"
+	distros_dir         = "distros_dir"
+	auto_sync           = "auto_sync"
 )
 
 // Configurations that are required for dotf to function properly
 var (
 	requiredConfigKeys = map[string]bool{
-		userspacedir:     true,
-		distrosdir:       false,
-		dotfilesdir:      true,
-		syncdir:          true,
-		autosync:         false,
-		syncintervalsecs: true,
+		userspace_dir:       true,
+		dotfiles_dir:        true,
+		dotfiles_shared_dir: true,
+		sync_dir:            true,
+		sync_interval_secs:  true,
+		distros_dir:         false,
+		auto_sync:           false,
 	}
 )
 
@@ -60,37 +63,36 @@ type ConfigMetadata struct {
 	Filepath string `json:"filepath"` // Not configurable
 }
 
+// DotfConfiguration configures dotf to do its work. The json annotation is used during parsing and
+// must match the requiredConfigKeys map.
 type DotfConfiguration struct {
 	*ConfigMetadata
-	UserspaceDir     string `json:"userspacedir"`     // Userspace dir is the root of the file hierachy dotf replicates
-	DistrosDir       string `json:"distrosdir"`       // Directory where the different distributions are placed
-	DotfilesDir      string `json:"dotfilesdir"`      // Directory inside SyncDir containing same structure as userspace dir
-	SyncDir          string `json:"syncdir"`          // Git initialized directory that dotf should sync with remote
-	AutoSync         bool   `json:"autosync"`         // If dotf-tray should autosync at given interval
-	SyncIntervalSecs int    `json:"syncintervalsecs"` // Interval between syncing with remote using dotf-tray application
+	UserspaceDir      string `json:"userspace_dir"`       // Userspace dir is the root of the file hierachy dotf replicates
+	DistrosDir        string `json:"distros_dir"`         // Directory where the different distributions are placed
+	DotfilesDir       string `json:"dotfiles_dir"`        // Directory inside SyncDir containing same structure as userspace dir
+	DotfilesSharedDir string `json:"dotfiles_shared_dir"` // Directory containing dotfiles shared or sourced distro files
+	SyncDir           string `json:"sync_dir"`            // Git initialized directory that dotf should sync with remote
+	AutoSync          bool   `json:"auto_sync"`           // If dotf-tray should autosync at given interval
+	SyncIntervalSecs  int    `json:"sync_interval_secs"`  // Interval between syncing with remote using dotf-tray application
 }
 
 /* Creates a basic sensible Configuration with default values. */
 func NewSensibleConfiguration() *DotfConfiguration {
 	return &DotfConfiguration{
-		ConfigMetadata:   &ConfigMetadata{Filepath: defaultConfigDir},
-		UserspaceDir:     homedir,
-		DistrosDir:       defaultDistrosDir,
-		DotfilesDir:      defaultDotfilesDir,
-		SyncDir:          defaultSyncDir,
-		AutoSync:         false,
-		SyncIntervalSecs: 3600,
+		ConfigMetadata:    &ConfigMetadata{Filepath: defaultConfigDir},
+		UserspaceDir:      homedir,
+		DistrosDir:        defaultDistrosDir,
+		DotfilesDir:       defaultDotfilesDir,
+		DotfilesSharedDir: defaultSharedDotfilesDir,
+		SyncDir:           defaultSyncDir,
+		AutoSync:          false,
+		SyncIntervalSecs:  3600,
 	}
 }
 
 func NewEmptyConfiguration() *DotfConfiguration {
 	return &DotfConfiguration{
 		ConfigMetadata:   &ConfigMetadata{Filepath: ""},
-		UserspaceDir:     "",
-		DistrosDir:       "",
-		DotfilesDir:      "",
-		SyncDir:          "",
-		AutoSync:         false,
 		SyncIntervalSecs: 3600,
 	}
 }
@@ -269,8 +271,8 @@ func parseTOMLFile(file *os.File) (map[string]string, error) {
 			continue
 		}
 
-		// Didn't get both key and value
 		if len(nameAndValue) < 2 {
+			// Didn't get both key and value
 			return nil, errors.New(
 				fmt.Sprintf(
 					"malformed key in configuration on line number: %d: %s",
@@ -301,21 +303,23 @@ func sanitize(r rune) bool {
 func buildConfiguration(config *DotfConfiguration, keyToValue map[string]string) error {
 	for k, v := range keyToValue {
 		switch k {
-		case userspacedir:
+		case userspace_dir:
 			config.UserspaceDir = expandTilde(v)
-		case distrosdir:
+		case distros_dir:
 			config.DistrosDir = expandTilde(v)
-		case dotfilesdir:
+		case dotfiles_dir:
 			config.DotfilesDir = expandTilde(v)
-		case syncdir:
+		case dotfiles_shared_dir:
+			config.DotfilesSharedDir = expandTilde(v)
+		case sync_dir:
 			config.SyncDir = expandTilde(v)
-		case syncintervalsecs:
+		case sync_interval_secs:
 			if v_num, err := strconv.Atoi(v); err != nil {
 				return err
 			} else {
 				config.SyncIntervalSecs = v_num
 			}
-		case autosync:
+		case auto_sync:
 			config.AutoSync = true
 		default:
 			return &MalformedConfigurationError{fmt.Sprint(


### PR DESCRIPTION
Intention is to be able to install configs into userspace while sourcing a shared parent config. 

Something like `dotf install /path/to/shared/file --source`.

1. Create file in dotfiles at same path including shell sourcing of the shared version at the top
2. Install it into userspace

Questions
- Q: What happens when reverting dotfile to userspace?
  - A: It should just keep sourcing the shared file.